### PR TITLE
Adds some more docs for models

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,10 @@ using Aleph
 
 
 abstractions = ["abstractions.md"]
+models = ["3d_dry_euler_total_energy.md",
+          "3d_moist_euler_total_energy.md",
+          "barotropic_fluid.md",
+         ]
 
 makedocs(
     sitename = "Aleph",
@@ -11,6 +15,7 @@ makedocs(
     pages = [
     "Home" => "index.md",
     "Abstractions" => abstractions,
+    "Models" => models,
     "Contributor Guide" => "contributor_guide.md",
     "Function Index" => "function_index.md",
     ],

--- a/docs/src/3d_dry_euler_total_energy.md
+++ b/docs/src/3d_dry_euler_total_energy.md
@@ -1,0 +1,56 @@
+# Dry Compressible Euler with Total Energy
+The Julia struct 
+```julia
+ThreeDimensionalMoistCompressibleEulerWithTotalEnergy()
+```
+
+is a shorthand for the following base set of equations
+
+```math
+    \begin{align}
+    \partial_t \rho + \nabla \cdot (\rho \vec{u})  &= 0 
+    \label{eq:continuity}
+    \\
+    \partial_t (\rho \vec{u}) + \nabla \cdot (\rho \vec{u} \otimes \vec{u} + p I)  &= 0 
+    \label{eq:momentum}
+    \\
+        \partial_t (\rho e) + \nabla \cdot ( \vec{u} [\rho e + p])  &= 0 
+    \label{eq:energy}
+    \end{align}
+``` 
+
+where the variables are
+1. $\rho$  :  density
+2. $\rho u $ : momentum
+3. $\rho e $ : total energy
+4. $p$  : pressure
+
+Pressure is given by the ideal gas law
+```math
+    \begin{align}
+    p = R_d T
+    \label{eq:ideal_gas}
+    \end{align}
+```
+and temperature is diagnosed from the prognostic variables via
+```math
+    \begin{align}
+    T  = T_0 +  \frac{\rho e -  \frac{1}{2} \rho \vec{u} \cdot \vec{u} - \rho \phi }{cv_d \rho  }
+    \label{eq:ideal_gas}
+    \end{align}
+```
+Here $T_0$ is a reference temperature.
+
+## Additional Sources
+
+The momentum equations may be augmented with source terms such as a coriolis force as well as gravity term
+
+```math
+    \begin{align}
+    \partial_t \rho + \nabla \cdot (\rho \vec{u})  &= 0 
+    \\
+    \partial_t (\rho \vec{u}) + \nabla \cdot (\rho \vec{u} \otimes \vec{u} + p I)  &= - \vec{\Omega} \times \rho u + \rho \nabla \phi
+    \\
+        \partial_t (\rho e) + \nabla \cdot ( \vec{u} [\rho e + p])  &= 0 
+    \end{align}
+```

--- a/docs/src/3d_moist_euler_total_energy.md
+++ b/docs/src/3d_moist_euler_total_energy.md
@@ -1,0 +1,62 @@
+# Moist Compressible Euler with Total Energy
+The Julia struct 
+```julia
+ThreeDimensionalMoistCompressibleEulerWithTotalEnergy()
+```
+
+is a shorthand for the following base set of equations
+
+```math
+    \begin{align}
+    \partial_t \rho + \nabla \cdot (\rho \vec{u})  &= 0 
+    \label{eq:continuity}
+    \\
+    \partial_t (\rho \vec{u}) + \nabla \cdot (\rho \vec{u} \otimes \vec{u} + p I)  &= 0 
+    \label{eq:momentum}
+    \\
+        \partial_t (\rho e) + \nabla \cdot ( \vec{u} [\rho e + p])  &= 0 
+    \label{eq:energy}
+    \\
+    \partial_t (\rho q) + \nabla \cdot ( \vec{u}  \rho q )  &= 0 
+    \label{eq:moisture}
+    \end{align}
+``` 
+
+where the variables are
+1. $\rho$  :  density
+1. $\rho u $ : momentum
+1. $\rho e $ : total energy
+1. $\rho q $ : total moisture
+1. $p$  : pressure
+
+Pressure is given by the ideal gas law
+```math
+    \begin{align}
+    p = R_d T
+    \label{eq:ideal_gas}
+    \end{align}
+```
+and temperature is diagnosed from the prognostic variables via
+```math
+    \begin{align}
+    T  = T_0 +  \frac{\rho e -  \frac{1}{2} \rho \vec{u} \cdot \vec{u} - \rho \phi - \rho q e_0  }{cv_m \rho  }
+    \label{eq:ideal_gas}
+    \end{align}
+```
+Here $T_0$ is a reference temperature.
+
+## Additional Sources
+
+The momentum equations may be augmented with source terms such as a coriolis force as well as gravity term
+
+```math
+    \begin{align}
+    \partial_t \rho + \nabla \cdot (\rho \vec{u})  &= 0 
+    \\
+    \partial_t (\rho \vec{u}) + \nabla \cdot (\rho \vec{u} \otimes \vec{u} + p I)  &= - \vec{\Omega} \times \rho u + \rho \nabla \phi
+    \\
+        \partial_t (\rho e) + \nabla \cdot ( \vec{u} [\rho e + p])  &= 0 
+    \\ 
+    \partial_t (\rho q) + \nabla \cdot ( \vec{u}  \rho q )  &= 0 
+    \end{align}
+```

--- a/docs/src/abstractions.md
+++ b/docs/src/abstractions.md
@@ -30,7 +30,7 @@ For example, a struct may be a placeholder for the following Euler Equations
         \partial_t (\rho e) + \nabla \cdot ( \vec{u} [\rho e + p])  &= 0 
     \label{eq:energy}
     \\
-    \rho e -  \frac{1}{2} \rho \vec{u} \cdot \vec{u} - \rho \phi  &= p
+    (\gamma-1) (\rho e -  \frac{1}{2} \rho \vec{u} \cdot \vec{u} - \rho \phi  ) &= p
     \label{eq:pressure}
     \end{align}
 ```

--- a/docs/src/barotropic_fluid.md
+++ b/docs/src/barotropic_fluid.md
@@ -1,0 +1,35 @@
+# Barotropic Fluid
+The Julia struct 
+```julia
+ThreeDimensionalCompressibleEulerWithBarotropicFluid()
+```
+
+is a shorthand for the following base set of equations
+
+```math
+    \begin{align}
+    \partial_t \rho + \nabla \cdot (\rho \vec{u})  &= 0 
+    \label{eq:continuity}
+    \\
+    \partial_t (\rho \vec{u}) + \nabla \cdot (\rho \vec{u} \otimes \vec{u} + p I)  &= 0 
+    \label{eq:momentum}
+    \\
+    \partial_t (\rho \theta) + \nabla \cdot ( \vec{u}  \rho \theta )  &= 0 
+    \label{eq:temperature}
+    \end{align}
+``` 
+
+where the variables are
+1. $\rho$  :  density
+1. $\rho u $ : momentum
+1. $\rho \theta $ : potential temperature
+1. $p$  : pressure
+
+Pressure is given by
+```math
+    \begin{align}
+    p =  \frac{c_s^2}{\rho_0}\rho^2
+    \label{eq:barotropic_pressure}
+    \end{align}
+```
+where $c_s$ is a constant (related to the soundspeed) and $\rho_0$ is a reference density


### PR DESCRIPTION
This pull request adds some documentation for the following models
1. ThreeDimensionalCompressibleEulerWithBarotropicFluid()
2. ThreeDimensionalDryCompressibleEulerWithTotalEnergy()
3. ThreeDimensionalMoistCompressibleEulerWithTotalEnergy()

The new documentation provides a description of the equations as well as what happens when nobs are added for coriolis or gravity